### PR TITLE
ssl_error_handling

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -1,6 +1,9 @@
 from bs4 import BeautifulSoup
 from urllib.request import urlopen
+import ssl
 
+# To Mute the SSL Certificate Verification
+ssl._create_default_https_context = ssl._create_unverified_context
 
 def read_localfile(file):
     '''Read file'''


### PR DESCRIPTION
ssl._create_default_https_context = ssl._create_unverified_context to mute ssl error while execution